### PR TITLE
fix display of password policy

### DIFF
--- a/login/login-update-password.ftl
+++ b/login/login-update-password.ftl
@@ -13,7 +13,7 @@
                 </div>
                 <div class="${properties.kcInputWrapperClass!}">
                     <input type="password" id="password-new" name="password-new" class="${properties.kcInputClass!}" autofocus autocomplete="new-password" />
-                    <div class="suggestion">${msg("passwordPolicy")}</div>
+                    <div class="suggestion">${kcSanitize(msg("passwordPolicy"))?no_esc}</div>
                 </div>
             </div>
 

--- a/login/resources/css/style.css
+++ b/login/resources/css/style.css
@@ -13,6 +13,7 @@
 }
 #kc-header {
     margin-top: 0;
+    margin-bottom: 24px;
 }
 h1#kc-page-title {
     margin-top: 24px;


### PR DESCRIPTION
The password display policy is currently displayed containing html tags:
![Screen Shot 2021-09-13 at 12 19 42 PM](https://user-images.githubusercontent.com/12942714/133143818-09402851-9a3b-46c9-9289-2c870f33b68c.png)

Fix is to include directive not to escape html tags
