### PR TITLE
fix buttons spacing issue on terms

### DIFF
--- a/login/resources/css/style.css
+++ b/login/resources/css/style.css
@@ -22,6 +22,12 @@
 h1#kc-page-title {
     margin-top: 24px;
 }
+.card-pf form.form-actions .btn {
+    margin-bottom: 16px;
+}
+.btn {
+    border-radius: 24px;
+}
 .btn-primary {
     background-image: none;
     background-color: #00838f;


### PR DESCRIPTION
Noticed styling issue on terms page:
![Screen Shot 2021-09-14 at 4 27 49 AM](https://user-images.githubusercontent.com/12942714/133250782-bfda9fd2-564e-4a34-ac6c-fc9d361b835c.png)

Fix includes:

Increasing space between buttons
fix border radius to be uniform across buttons