### PR TITLE
Revert "update username field label to username"

### DIFF
--- a/login/login.ftl
+++ b/login/login.ftl
@@ -8,7 +8,7 @@
         <#if realm.password>
             <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
                 <div class="${properties.kcFormGroupClass!}">
-                    <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("username")}</#if></label>
+                    <label for="username" class="${properties.kcLabelClass!}"><#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if></label>
 
                     <#if usernameEditDisabled??>
                         <input tabindex="1" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}" type="text" disabled />


### PR DESCRIPTION
Reverts uwcirg/cosri-keycloak-theme#10

Use [default Keycloak logic](https://github.com/keycloak/keycloak/blob/master/themes/src/main/resources/theme/base/login/login-username.ftl#L13) for selecting username field label